### PR TITLE
Fixed bug for Repeated Courses

### DIFF
--- a/gpameter.user.js
+++ b/gpameter.user.js
@@ -37,7 +37,7 @@ add_checkboxes = function(){
 		var course_id = $(this).children(".col1").html().trim();
 		if (courses_checked.has(course_id)){
 			append_checkbox($(this).children(".col1"), false);
-            return;
+			return;
 		}
 		is_checked = true;
 		type = $(this).children(".col5").html().trim().slice(6);


### PR DESCRIPTION
Fixes #2
To fix that bug, each course name is remembered as it is calculated. When a new course with same name comes up, it is ignored.